### PR TITLE
Feat/add default import for easier instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ arbitrary javascript scripts which means `.js.erb` is not supported.
 ## What can it do right now?
 
 In it's current state, Mrujs is a native fetch wrapper and
-a form wrapper that can marshal an HTML / JSON / XML / any response 
-you want and can be listened for via event listeners. For 
+a form wrapper that can marshal an HTML / JSON / XML / any response
+you want and can be listened for via event listeners. For
 a list of things to be implemented in the future, checkout
 the [Roadmap](#roadmap) below.
 
@@ -30,15 +30,15 @@ the [Roadmap](#roadmap) below.
 yarn add mrujs
 ```
 
-2. Go to your Webpacker entrypoint and import `Mrujs` and start it up.
+2. Go to your Webpacker entrypoint and import `mrujs` and start it up.
 
 ```js
 // app/javascript/packs/application.js
 
 // ... other stuff
 
-import { Mrujs } from "mrujs";
-window.mrujs = new Mrujs().start();
+import mrujs from "mrujs";
+window.mrujs = mrujs.start();
 ```
 
 3. Using on a form
@@ -235,9 +235,9 @@ Maybe you dont like my fetch wrapper, thats fine! To use native fetch
 heres all you have to do to include the CSRF-Token.
 
 ```js
-import { Mrujs } from "mrujs"
+import mrujs from "mrujs"
 
-window.mrujs = new Mrujs().start()
+window.mrujs =  mrujs.start()
 window.fetch("url", {
   headers: {
     "X-CSRF-TOKEN": window.mrujs.csrfToken

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,8 +6,8 @@
     <meta name="csrf-param" content="authenticity_token">
     <meta name="csrf-token" content="1234">
     <script type="module">
-      import { Mrujs } from '../src/index';
-      window.mrujs = new Mrujs().start()
+      import mrujs from '../src/index';
+      window.mrujs = mrujs.start()
     </script>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mrujs",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "UJS for modern javascript. mrujs stands for Modern Rails UJS",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,4 +7,7 @@ declare global {
   }
 }
 
+const mrujs = new Mrujs()
+
 export { Mrujs }
+export default mrujs

--- a/test/ajax/ajaxFetchEvents.test.ts
+++ b/test/ajax/ajaxFetchEvents.test.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon'
 
 import { doNothing, assertFired } from '../helpers'
 import { ALWAYS_SENT_EVENTS } from './ajaxHelpers'
-import { Mrujs } from '../../src/index'
+import mrujs from '../../src/index'
 
 describe('Ajax Fetch', (): void => {
   afterEach((): void => {
@@ -13,15 +13,12 @@ describe('Ajax Fetch', (): void => {
   it('Should call native window.fetch', async (): Promise<void> => {
     const stub = sinon.stub(window, 'fetch')
 
-    const mrujs = new Mrujs()
     await mrujs.fetch({ url: '/test' })
     assert(stub.calledOnce)
   })
 
   it('Should dispatch a fetch events and go through the full lifecycle', (): void => {
     const events = [...ALWAYS_SENT_EVENTS, 'ajax:send']
-
-    const mrujs = new Mrujs().start()
 
     mrujs.fetch({ url: '/test', dispatchEvents: true }) as null
     events.forEach(event => {

--- a/test/ajax/ajaxFormEvents.test.ts
+++ b/test/ajax/ajaxFormEvents.test.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon'
 
 import { doNothing, assertFired, findByTestId } from '../helpers'
 import { ALWAYS_SENT_EVENTS } from './ajaxHelpers'
-import { Mrujs } from '../../src/index'
+import mrujs from '../../src/index'
 
 describe('Ajax', (): void => {
   afterEach((): void => {
@@ -16,7 +16,7 @@ describe('Ajax', (): void => {
 
       const stub = sinon.stub(window, 'fetch')
 
-      window.mrujs = new Mrujs().start()
+      window.mrujs = mrujs.start()
 
       events.forEach(event => {
         assertFired(event, doNothing)
@@ -31,7 +31,7 @@ describe('Ajax', (): void => {
     const submitButton = findByTestId('GET-200')?.querySelector("input[type='submit']") as HTMLInputElement | null
 
     const submitGet200 = (): void => {
-      window.mrujs = new Mrujs().start()
+      window.mrujs = mrujs.start()
 
       const submitButton = findByTestId('GET-200')?.querySelector("input[type='text']") as HTMLInputElement | null
 
@@ -67,7 +67,7 @@ describe('Ajax', (): void => {
     const events = [...ALWAYS_SENT_EVENTS, 'ajax:response:error']
 
     const submitGet404 = (): void => {
-      window.mrujs = new Mrujs().start()
+      window.mrujs = mrujs.start()
       const inputEl = findByTestId('GET-404')?.querySelector("input[type='text']") as HTMLInputElement | null
       if (inputEl != null) {
         inputEl.value = '1234'

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,14 +1,14 @@
 import { assert } from '@esm-bundle/chai'
-import { Mrujs } from '../src/index'
+import mrujs, { Mrujs } from '../src/index'
 
 describe('index', () => {
   it('Should set a top level mrujs on the window', () => {
-    window.mrujs = new Mrujs().start()
+    window.mrujs = mrujs.start()
     assert(window.mrujs instanceof Mrujs)
   })
 
   it('Should retrieve the proper csrf token', () => {
-    window.mrujs = new Mrujs().start()
+    window.mrujs = mrujs.start()
     assert.equal(window.mrujs.csrfToken, '1234')
   })
 })


### PR DESCRIPTION
This is for you @leastbad ! Allows a user to do:

```js
import mrujs from "mrujs"
window.mrujs = mrujs.start()
```