### PR TITLE
hack first implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
       "dist"
     ],
     "project": "./tsconfig-dev.json"
+  },
+  "dependencies": {
+    "morphdom": "^2.6.1"
   }
 }

--- a/src/mrujs.ts
+++ b/src/mrujs.ts
@@ -67,7 +67,7 @@ export class Mrujs {
   }
 
   connect (): void {
-    console.log('MRUJS: Connecting')
+    // console.log('MRUJS: Connecting')
     this.csrf.connect()
     this.clickHandler.connect()
     this.confirmClass.connect()
@@ -90,7 +90,7 @@ export class Mrujs {
   }
 
   disconnect (): void {
-    console.log('MRUJS: disconnecting')
+    // console.log('MRUJS: disconnecting')
     this.csrf.disconnect()
     this.clickHandler.disconnect()
     this.confirmClass.disconnect()

--- a/src/turbolinksAdapter.ts
+++ b/src/turbolinksAdapter.ts
@@ -1,3 +1,5 @@
+import morphdom from 'morphdom'
+
 export class TurbolinksAdapter {
   __turbolinksVisit__!: Function
 
@@ -19,12 +21,33 @@ export class TurbolinksAdapter {
     if (response == null) return
     if (response.redirected != true) return
 
-    const action = 'advance'
+    // const action = 'advance'
 
     // TODO: When should we actually use replace other than when specified??
+    // leastbad says: this should be advance unless data-turbolinks-action="replace"
     //   action = 'replace'
 
-    window.Turbolinks.clearCache()
-    window.Turbolinks.visit(location, { action })
+    // i think that this should only happen if data-ujs-morph has been set, otherwise default to Turbolinks visit
+    this.body(event).then(html => {
+      const template = document.createElement('template')
+      template.innerHTML = String(html).trim()
+      morphdom(document.body, template.content, {childrenOnly: true})
+      
+      window.history.pushState({}, '', response.url)
+      // this is obviously not the right thing to do, but we need to tell mrujs to re-init
+      // this hack is causing InvalidAuthenticityToken exceptions in my app when I try to log out
+      document.dispatchEvent(new CustomEvent('turbolinks:load'))
+    })
+
+    // wherever you handle remote forms, we can use the morphdom trick but not do the pushState if there's an error
+    // so depending on the HTTP error that comes back... I guess 4xx errors, right?
+    // seems like 5xx errors should be handled by the app directly
+
+    // window.Turbolinks.clearCache()
+    // window.Turbolinks.visit(location, { action })
+  }
+
+  async body (event: CustomEvent): Promise<string>  {
+    return await event.detail.response.text()
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6200,6 +6200,11 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+morphdom@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/morphdom/-/morphdom-2.6.1.tgz#e868e24f989fa3183004b159aed643e628b4306e"
+  integrity sha512-Y8YRbAEP3eKykroIBWrjcfMw7mmwJfjhqdpSvoqinu8Y702nAwikpXcNFDiIkyvfCLxLM9Wu95RZqo4a9jFBaA==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
It lives!

This is obviously not intended to be merged - it is wildly broken and only kinda/sorta solves my specific use case. But I figured out how to do async/await in TypeScript and **it works**.

Ironically, the thing that is currently breaking unacceptably right now is trying to log out after using this to log in.

I still think that the standard `window.Turbolinks.visit()` stuff should be the default, but let's introduce `data-ujs-morph` or something. Anyhow, lots of comments in here, hopefully useful.