### PR TITLE
feat: allow response bodies to be consumed multiple times.

### DIFF
--- a/src/http/fetchResponse.ts
+++ b/src/http/fetchResponse.ts
@@ -4,6 +4,7 @@ import { expandUrl } from '../utils/url'
 // https://github.com/hotwired/turbo/blob/main/src/http/fetch_response.ts
 export class FetchResponse {
   readonly response: Response
+  private __responseHtml__!: Promise<string>
 
   constructor (response: Response) {
     this.response = response
@@ -51,7 +52,9 @@ export class FetchResponse {
 
   get responseHtml (): Promise<string> {
     if (this.isHtml) {
-      return this.response.text()
+      if (this.__responseHtml__ != null) return this.__responseHtml__
+
+      return (this.__responseHtml__ = this.response.text())
     } else {
       return Promise.reject(this.response)
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 import { Mrujs } from './mrujs'
+import { FetchRequest } from './http/fetchRequest'
+import { FetchResponse } from './http/fetchResponse'
 
 // This is required for typescript checking in tests
 declare global {
@@ -12,4 +14,5 @@ declare global {
 const mrujs = new Mrujs()
 
 export { Mrujs }
+export { FetchRequest, FetchResponse }
 export default mrujs

--- a/test/js/ajax/ajax.test.html
+++ b/test/js/ajax/ajax.test.html
@@ -43,7 +43,7 @@
 
       runTests(async () => {
         await import('./ajaxFormEvents.test');
-        await import('./ajaxFetchEvents.test');
+        await import('./ajaxFetch.test');
       });
     </script>
   </body>

--- a/test/js/ajax/ajaxFetch.test.ts
+++ b/test/js/ajax/ajaxFetch.test.ts
@@ -1,7 +1,7 @@
 import { assert } from '@esm-bundle/chai'
 import sinon from 'sinon'
 
-import mrujs from '../../../src/index'
+import mrujs, { FetchResponse } from '../../../src/index'
 
 describe('Ajax Fetch', (): void => {
   afterEach((): void => {
@@ -13,5 +13,11 @@ describe('Ajax Fetch', (): void => {
 
     await mrujs.fetch('/test')
     assert(stub.calledOnce)
+  })
+
+  it('Should be able to consume body twice', async (): Promise<void> => {
+    const response = new FetchResponse(await mrujs.fetch('/'))
+    await response.responseHtml
+    await response.responseHtml
   })
 })


### PR DESCRIPTION
## Status

Ready

## What this does

- Allows for responseBodies to be consumed multiple times.

```js
const response = new FetchResponse(await window.fetch())
await response.responseHtml
await response.responseHtml // => no error.
```
