### PR TITLE
Fix/double loads with turbolinks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mrujs",
-  "version": "0.3.0-beta.7",
+  "version": "0.3.0-beta.8",
   "description": "UJS for modern javascript. mrujs stands for Modern Rails UJS",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/src/navigationAdapter.ts
+++ b/src/navigationAdapter.ts
@@ -75,7 +75,7 @@ export class NavigationAdapter {
           window.Turbolinks.controller.cache.put(location, snapshot)
           action = 'restore'
           window.Turbolinks.visit(location, { action })
-        })
+        }).catch((error) => console.error(error))
         return
       }
 

--- a/src/navigationAdapter.ts
+++ b/src/navigationAdapter.ts
@@ -12,11 +12,6 @@ const ALLOWABLE_ACTIONS = [
 
 type VisitAction = 'advance' | 'replace' | 'restore'
 
-interface VisitInit {
-  location: URL | string
-  action: VisitAction
-}
-
 export class NavigationAdapter {
   private readonly __navigateViaEvent__: Function
 
@@ -72,7 +67,19 @@ export class NavigationAdapter {
     }
 
     if (response.succeeded && this.useTurbolinks) {
-      this.turbolinksVisit({ location, action })
+      window.Turbolinks.clearCache()
+
+      if (response.isHtml) {
+        response.responseHtml.then((html) => {
+          const snapshot = window.Turbolinks.Snapshot.wrap(html)
+          window.Turbolinks.controller.cache.put(location, snapshot)
+          action = 'restore'
+          window.Turbolinks.visit(location, { action })
+        })
+        return
+      }
+
+      window.Turbolinks.visit(location, { action })
       return
     }
 
@@ -85,11 +92,6 @@ export class NavigationAdapter {
     if (window.Turbolinks.supported !== true) return false
 
     return true
-  }
-
-  turbolinksVisit ({ location, action }: VisitInit): void {
-    window.Turbolinks.clearCache()
-    window.Turbolinks.visit(location, { action })
   }
 
   morphResponse (response: FetchResponse): void {


### PR DESCRIPTION
## Status

Ready

## What this does

- Fixes double navigation when navigating with Turbolinks.
- Turbolinks would fire a 2nd request despite the cache already being up to date.

Co-authored-by: domchristie <christiedom@gmail.com>