### PR TITLE
feat: add ajax:stopped event

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ ajax:response:error
 ajax:error # => will catch both request and response errors.
 ajax:success # => will only fire if no errors
 ajax:complete
+ajax:stopped # => when event.preventDefault() is called or event.detail.fetchRequest.cancel(event) is called.
 ```
 
 * Diagram of Ajax form submissions
@@ -102,6 +103,18 @@ ajax:complete
 <img width="632" alt="Screen Shot 2021-06-10 at 3 23 02 AM" src="https://user-images.githubusercontent.com/26425882/121482581-47675400-c99b-11eb-9a72-79a09c33ad34.png">
 
 [mrujs-remote-form-event-diagram.pdf](https://github.com/ParamagicDev/mrujs/files/6629160/mrujs-remote-form-event-diagram.pdf)
+
+### All properties available on event.detail
+
+```js
+element // => either form or link element that initiated request
+fetchRequest // => FetchRequest (wrapper around Request)
+request // => Request
+fetchResponse // => FetchResponse (wrapper around Response)
+response // => Response
+submitter // => The button clicked to initiate the submit. Button / Link element
+submission // => Either FormSubmission or LinkSubmission.
+```
 
 #### Note about remote / ajax links
 
@@ -114,21 +127,13 @@ how submit events are intercepted.
 Cancelling Ajax events is fairly straightforward with only 1 edge case
 with `ajax:send`.
 
-You can cancel events at anytime simply by calling `event.preventDefault()` or
-`event.stopImmediatePropagation()`:
+You can cancel events at anytime simply by calling `event.preventDefault()`.
 
 Example:
 
 ```js
-// Should just work...
 document.querySelector("form").addEventListener("ajax:before", (event) => {
   event.preventDefault();
-})
-
-// For extra certainty that no others events get sent.
-document.querySelector("form").addEventListener("ajax:before", (event) => {
-  event.preventDefault();
-  event.stopImmediatePropagation();
 })
 ```
 
@@ -137,7 +142,8 @@ controller. To do so, you would do the following:
 
 ```js
 document.querySelector("form").addEventListener("ajax:send", (event) => {
-  event.detail.fetchRequest.cancel()
+  event.detail.fetchRequest.cancel(event)
+  // => If event is not passed in, it wont fire a `ajax:stopped` event.
 })
 ```
 </details>

--- a/src/formSubmitDispatcher.ts
+++ b/src/formSubmitDispatcher.ts
@@ -54,7 +54,10 @@ export class FormSubmitDispatcher {
    * The request can be found via `event.detail.request`
    */
   startFetchRequest (event: CustomEvent): void {
-    if (event.defaultPrevented) return
+    if (event.defaultPrevented) {
+      this.dispatchStopped(event)
+      return
+    }
 
     const { element, fetchRequest, request, submitter }: AjaxEventDetail = event.detail
 
@@ -64,7 +67,10 @@ export class FormSubmitDispatcher {
   }
 
   async sendFetchRequest (event: CustomEvent): Promise<void> {
-    if (event.defaultPrevented) return
+    if (event.defaultPrevented) {
+      this.dispatchStopped(event)
+      return
+    }
 
     const { request } = event.detail
 
@@ -87,7 +93,10 @@ export class FormSubmitDispatcher {
    * { response, request?, error?, submitter } = detail
    */
   dispatchComplete (event: CustomEvent): void {
-    if (event.defaultPrevented) return
+    if (event.defaultPrevented) {
+      this.dispatchStopped(event)
+      return
+    }
 
     dispatch.call(this.findTarget(event), AJAX_EVENTS.ajaxComplete, {
       detail: { ...event.detail }
@@ -129,12 +138,23 @@ export class FormSubmitDispatcher {
    * { response, request?, error?, submitter } = event.detail
    */
   dispatchError (event: CustomEvent): void {
-    if (event.defaultPrevented) return
+    if (event.defaultPrevented) {
+      this.dispatchStopped(event)
+      return
+    }
 
     const { element, fetchRequest, request, fetchResponse, response, submitter } = event.detail
 
     dispatch.call(this.findTarget(event), AJAX_EVENTS.ajaxError, {
       detail: { element, fetchRequest, request, fetchResponse, response, submitter }
+    })
+  }
+
+  // This is only for when event.defaultPrevented() is called.
+  // if a user calls `event.detail.submission.cancel()`, that will be triggered separately.
+  dispatchStopped (event: CustomEvent): void {
+    dispatch.call(this.findTarget(event), AJAX_EVENTS.ajaxStopped, {
+      detail: { ...event.detail }
     })
   }
 

--- a/src/http/fetchRequest.ts
+++ b/src/http/fetchRequest.ts
@@ -1,3 +1,4 @@
+import { AJAX_EVENTS, dispatch, stopEverything } from '../utils/events'
 import { mergeHeaders, expandUrl, Locateable } from '../utils/url'
 
 export type FetchRequestBody = URLSearchParams | ReadableStream<Uint8Array>
@@ -56,8 +57,19 @@ export class FetchRequest {
     return this.body instanceof URLSearchParams ? Array.from(this.body.entries()) : []
   }
 
-  cancel (): void {
+  cancel (event?: CustomEvent): void {
     this.abortController.abort()
+
+    // trigger event dispatching if an event gets passed in.
+    if (event != null) {
+      stopEverything(event)
+
+      const { element } = event.detail
+
+      dispatch.call(element, AJAX_EVENTS.ajaxStopped, {
+        detail: { ...event.detail }
+      })
+    }
   }
 
   modifyUrl (url: Locateable): void {

--- a/src/mrujs.ts
+++ b/src/mrujs.ts
@@ -75,10 +75,12 @@ export class Mrujs {
 
   connect (): void {
     this.csrf.connect()
+    document.addEventListener('submit', disableSubmitter as EventListener)
     this.clickHandler.connect()
     this.confirmClass.connect()
     this.method.connect()
     this.formSubmitDispatcher.connect()
+    document.addEventListener('ajax:complete', enableSubmitter as EventListener)
     this.navigationAdapter.connect()
 
     // This event works the same as the load event, except that it fires every
@@ -86,11 +88,6 @@ export class Mrujs {
     // See https://github.com/rails/jquery-ujs/issues/357
     // See https://developer.mozilla.org/en-US/docs/Using_Firefox_1.5_caching
     window.addEventListener('pageshow', this.reenableDisabledElements)
-
-    // This may need to be rethought to align with UJS
-    document.addEventListener('submit', disableSubmitter as EventListener)
-    document.addEventListener('ajax:complete', enableSubmitter as EventListener)
-    // end
 
     this.connected = true
   }

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -67,7 +67,9 @@ export const AJAX_EVENTS = {
    * After any fetch request, regardless of outcome
    * Does not have any accessible data besides the event itself
    */
-  ajaxComplete: `${prefix}:complete`
+  ajaxComplete: `${prefix}:complete`,
+
+  ajaxStopped: `${prefix}:stopped`
 
   // NOT CURRENTLY IMPLEMENTED
   // /**

--- a/test/js/ajax/ajaxEvents.test.ts
+++ b/test/js/ajax/ajaxEvents.test.ts
@@ -16,7 +16,7 @@ describe('Ajax', (): void => {
 
       const stub = sinon.stub(window, 'fetch')
 
-      window.mrujs = mrujs.start()
+      mrujs.start()
 
       events.forEach(event => {
         assertFired(event, doNothing)
@@ -38,6 +38,7 @@ describe('Ajax', (): void => {
 
     events.forEach(event => {
       it(`Should fire an ${event} 200 GET requests`, (): void => {
+        mrujs.start()
         assertFired(event, submitGet200)
       })
     })
@@ -66,7 +67,6 @@ describe('Ajax', (): void => {
     const events = [...ALWAYS_SENT_EVENTS, 'ajax:response:error', 'ajax:error']
 
     const submitGet404 = (): void => {
-      window.mrujs = mrujs.start()
       const inputEl = findByTestId('GET-404')?.querySelector("input[type='text']") as HTMLInputElement | null
       if (inputEl != null) {
         inputEl.value = '1234'
@@ -76,8 +76,34 @@ describe('Ajax', (): void => {
 
     events.forEach(event => {
       it(`Should fire an ${event} for 404 GET requests`, () => {
+        mrujs.start()
         assertFired(event, submitGet404)
       })
+    })
+  })
+
+  describe('Firing ajax:stopped', () => {
+    const event = 'ajax:stopped'
+
+    const submitGet200 = (): void => {
+      const submitButton = findByTestId('GET-200')?.querySelector("input[type='text']") as HTMLInputElement | null
+      submitButton?.click()
+    }
+
+    it('should fire on event.preventDefault()', () => {
+      mrujs.start()
+      const preventDefault = (event: CustomEvent): void => event.preventDefault()
+      document.addEventListener('ajax:before', preventDefault as EventListener)
+      assertFired(event, submitGet200)
+      document.removeEventListener('ajax:before', preventDefault as EventListener)
+    })
+
+    it('should fire on event.detail.fetchRequest.cancel()', () => {
+      mrujs.start()
+      const preventDefault = (event: CustomEvent): void => event.preventDefault()
+      document.addEventListener('ajax:before', preventDefault as EventListener)
+      assertFired(event, submitGet200)
+      document.removeEventListener('ajax:before', preventDefault as EventListener)
     })
   })
 


### PR DESCRIPTION
## Status

Ready

## Reasoning

When UJS events stop firing, it initiates an `ajax:stopped` event. This PR mimics that same behavior.
