### PR TITLE
Feat: content type shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ In it's current state, Mrujs is has about 95% feature parity with UJS.
 The goal of Mrujs is to be a drop-in replacement for UJS, but this is
 not possible in all cases.
 
+## Integrations
+
+Currently Mrujs is designed to work best with Turbolinks. Turbolinks is
+the current navigation adapter for Mrujs. In the future, there are plans
+to use regular navigation on the window and Turbo. Those have not been
+implemented yet but are on the roadmap.
+
+In addition, on unsuccessful form submissions, MorphDOM is used to morph
+responses from the server to provide a DOM diffed update page to display
+things like errors.
+
 ## Getting Started
 
 1. Install `mrujs`
@@ -49,17 +60,12 @@ Rails.start()
 If using Turbo, make sure to set Turbo to false.
 
 ```erb
-<%= form_with scope: Model, data: {remote: "true", turbo: "false"} do |form| %>
+<%= form_with scope: Model, data: {remote: "true"} do |form| %>
   <%= form.label :name %>
   <%= form.text_field :name %>
 
   <%= form.submit "Submit", data-disable-with: "Submitting..." %>
 <%= end %>
-
-<form action="/" method="post" data-remote="true" data-turbo="false">
-  <input id="foo" name="foo">
-  <input type="submit" value="Submit">
-</form>
 ```
 
 4. Stopping Mrujs
@@ -273,6 +279,34 @@ follow the above steps, but instead of calling `start`, you would call `mrujs.re
 
 A list of all `querySelectors` and their strings can be found in the
 [src/utils/dom.ts](/src/utils/dom.ts) file.
+
+### (Expiremental) MimeTypes
+
+Mrujs comes with a set of predefined MimeTypes for `AcceptHeaders`.
+These can be modified to include additional shortcuts.
+
+Here is an example of adding a custom CableCar mimetype.
+
+```js
+import mrujs from "mrujs"
+
+mrujs.registerMimeTypes(
+  [
+    {shortcut: "cablecar", header: "text/vnd.cablecar.json"}
+  ]
+)
+
+mrujs.start()
+```
+
+Then in a form you can do the following to set the proper Accept header
+with shorthand syntax.
+
+```html
+<form data-remote="true" data-type="cablecar"></form>
+```
+
+and this will set the Accept header to `"text/vnd.cablecar.json"`
 
 ## Developing locally
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mrujs",
-  "version": "0.3.0-beta.17",
+  "version": "0.3.0-beta.18",
   "description": "UJS for modern javascript. mrujs stands for Modern Rails UJS",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/src/http/fetchResponse.ts
+++ b/src/http/fetchResponse.ts
@@ -76,7 +76,7 @@ export class FetchResponse {
 
   // https://fetch.spec.whatwg.org/#fetch-api
   get isJson (): boolean {
-    return Boolean(this.contentType?.toLowerCase().match(/^application\/json/))
+    return Boolean(this.contentType?.toLowerCase().match(/(^application\/json|\.json$)/))
   }
 
   getHeader (name: string): string | null {

--- a/src/mrujs.ts
+++ b/src/mrujs.ts
@@ -14,7 +14,8 @@ import { FetchRequest } from './http/fetchRequest'
 import { FetchResponse } from './http/fetchResponse'
 import { BASE_SELECTORS } from './utils/dom'
 import { Locateable } from './utils/url'
-import { MrujsConfigInterface, QuerySelectorInterface } from './types'
+import { BASE_ACCEPT_HEADERS } from './utils/headers'
+import { MrujsConfigInterface, QuerySelectorInterface, MimeTypeInterface, CustomMimeTypeInterface } from './types'
 
 export class Mrujs {
   static FetchRequest = FetchRequest.constructor
@@ -34,7 +35,7 @@ export class Mrujs {
   boundReenableDisabledElements: EventListener
 
   constructor () {
-    this.config = { querySelectors: { ...BASE_SELECTORS } }
+    this.config = { querySelectors: { ...BASE_SELECTORS }, mimeTypes: { ...BASE_ACCEPT_HEADERS } }
     this.clickHandler = new ClickHandler()
     this.csrf = new Csrf()
     this.formSubmitDispatcher = new FormSubmitDispatcher()
@@ -135,6 +136,26 @@ export class Mrujs {
   async fetch (input: Request | Locateable, options: RequestInit = {}): Promise<Response> {
     const fetchRequest = new FetchRequest(input, options)
     return await window.fetch(fetchRequest.request)
+  }
+
+  registerMimeTypes (mimeTypes: CustomMimeTypeInterface[]): MimeTypeInterface {
+    const customMimeTypes: MimeTypeInterface = {}
+
+    mimeTypes.forEach((mimeType) => {
+      const { shortcut, header } = mimeType
+      customMimeTypes[shortcut] = header
+    })
+
+    this.config.mimeTypes = {
+      ...this.config.mimeTypes,
+      ...customMimeTypes
+    }
+
+    return this.mimeTypes
+  }
+
+  get mimeTypes (): MimeTypeInterface {
+    return this.config.mimeTypes
   }
 
   get querySelectors (): QuerySelectorInterface {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export interface AjaxEventDetail {
 
 export interface MrujsConfigInterface {
   querySelectors: QuerySelectorInterface
+  mimeTypes: MimeTypeInterface
 }
 
 export interface QuerySelectorInterface {
@@ -38,4 +39,13 @@ export interface QuerySelectorInterface {
 export interface SelectorInterface {
   selector: string
   exclude?: string
+}
+
+export interface CustomMimeTypeInterface {
+  shortcut: string
+  header: string
+}
+
+export interface MimeTypeInterface {
+  [key: string]: string
 }

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -1,4 +1,6 @@
-export const ACCEPT_HEADERS = {
+import { MimeTypeInterface } from '../types'
+
+export const BASE_ACCEPT_HEADERS: MimeTypeInterface = {
   '*': '*/*',
   any: '*/*',
   text: 'text/plain',
@@ -7,17 +9,19 @@ export const ACCEPT_HEADERS = {
   json: 'application/json, text/javascript'
 }
 
-export type AcceptHeadersType = '*' | 'any' | 'text' | 'html' | 'xml' | 'json'
-
 export function findResponseTypeHeader (responseType: string | undefined): string {
+  const acceptHeaders = {
+    ...window.mrujs.mimeTypes
+  }
+
   if (responseType == null) {
-    return ACCEPT_HEADERS.any
+    return acceptHeaders.any
   }
 
   responseType = responseType.trim()
 
-  if (Object.keys(ACCEPT_HEADERS).includes(responseType)) {
-    return ACCEPT_HEADERS[responseType as AcceptHeadersType]
+  if (Object.keys(acceptHeaders).includes(responseType)) {
+    return acceptHeaders[responseType]
   }
 
   return responseType

--- a/test/js/index.test.ts
+++ b/test/js/index.test.ts
@@ -1,15 +1,18 @@
 import { assert } from '@esm-bundle/chai'
 import mrujs, { Mrujs } from '../../src/index'
+import { BASE_ACCEPT_HEADERS } from '../../src/utils/headers'
 
 describe('index', () => {
   it('Should set a top level mrujs on the window', () => {
     mrujs.start()
     assert(window.mrujs instanceof Mrujs)
+    mrujs.stop()
   })
 
   it('Should retrieve the proper csrf token', () => {
     mrujs.start()
     assert.equal(window.mrujs.csrfToken, '1234')
+    mrujs.stop()
   })
 
   it('Should allow for custom querySelectors', () => {
@@ -19,5 +22,21 @@ describe('index', () => {
 
     mrujs.start()
     assert.include(mrujs.querySelectors.linkClickSelector.selector, 'my-custom-element')
+    mrujs.stop()
+  })
+
+  it('Should allow for custom mimetypes', () => {
+    const customMime = { shortcut: 'my-custom-mime', header: 'text/vnd.custom' }
+    mrujs.registerMimeTypes([customMime])
+    mrujs.start()
+
+    assert(mrujs.mimeTypes[customMime.shortcut] === customMime.header)
+
+    // Make sure we dont override existing headers
+    for (const [key, value] of Object.entries(BASE_ACCEPT_HEADERS)) {
+      assert(mrujs.mimeTypes[key] === value)
+    }
+
+    mrujs.stop()
   })
 })


### PR DESCRIPTION
## Status

Ready

## Additional Notes

Allows registering of custom content types for shortcutting `data-type`.

See README.md for more info on custom mime types.
