### PR TITLE
update documentation for fetch headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ To *receive* a `json` response, make sure to set the `Accept` header to
 ```js
 window.mrujs.fetch(
   "/url",
-  {"Accept": "application/json"}
+  {headers: {"Accept": "application/json"}}
 ).then(response => {}).catch(error => {})
 ```
 
@@ -191,7 +191,7 @@ To *send* a `json` payload, make sure to set the `Content-Type` header to
 window.mrujs.fetch(
   "/url",
   {
-    "Content-Type": "application/json",
+    headers: {"Content-Type": "application/json"},
     body: JSON.stringify(data)
   }
 ).then(response => {}).catch(error => {})


### PR DESCRIPTION
This was tripping me up but I got it to work by assigning headers within a `headers: {}` entry.  This is consistent with the standard fetch API.

## Status

* Ready

## Related Issue(s)


## Additional Notes
