### PR TITLE
Fix: remote link submissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mrujs",
-  "version": "0.3.0-beta.23",
+  "version": "0.3.0-beta.24",
   "description": "UJS for modern javascript. mrujs stands for Modern Rails UJS",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/src/method.ts
+++ b/src/method.ts
@@ -42,7 +42,7 @@ export class Method {
   handle (event: Event): void {
     stopEverything(event)
 
-    const element = event.target as HTMLAnchorElement
+    const element = event.currentTarget as HTMLAnchorElement
     const submitter = element
 
     const linkSubmission = new LinkSubmission(element)

--- a/src/method.ts
+++ b/src/method.ts
@@ -42,10 +42,10 @@ export class Method {
   handle (event: Event): void {
     stopEverything(event)
 
-    const element = event.currentTarget as HTMLAnchorElement
-    const submitter = element
+    const link = event.currentTarget as HTMLAnchorElement
+    const submitter = event.target
 
-    const linkSubmission = new LinkSubmission(element)
+    const linkSubmission = new LinkSubmission(link)
 
     const { fetchRequest, request } = linkSubmission
 
@@ -53,8 +53,8 @@ export class Method {
      * Send it through the event chain. use ajax:beforeSend because submit auto
      * populates fields that we dont want.
      */
-    dispatch.call(element, AJAX_EVENTS.ajaxBeforeSend, {
-      detail: { element, fetchRequest, request, submitter }
+    dispatch.call(link, AJAX_EVENTS.ajaxBeforeSend, {
+      detail: { element: link, fetchRequest, request, submitter }
     })
   }
 

--- a/test/js/ajax/ajax.test.html
+++ b/test/js/ajax/ajax.test.html
@@ -38,7 +38,10 @@
       <input type="submit" value="Submit" />
     </form>
 
-    <a data-testid="get-link" method="get" href="/">Delete link</a>
+    <a data-testid="get-link" data-remote="true" data-method="get" href="/">GET link</a>
+    <a data-testid="delete-link" data-method="delete" href="/">
+      <button data-testid="delete-button">Delete link</button>
+    </a>
 
     <script type="module">
       import { runTests } from '@web/test-runner-mocha';

--- a/test/js/ajax/ajax.test.html
+++ b/test/js/ajax/ajax.test.html
@@ -38,7 +38,7 @@
       <input type="submit" value="Submit" />
     </form>
 
-    <a data-testid="get-link" data-remote="true" data-method="get" href="/">GET link</a>
+    <a data-testid="get-link" data-remote="true" href="/">GET link</a>
     <a data-testid="delete-link" data-method="delete" href="/">
       <button data-testid="delete-button">Delete link</button>
     </a>

--- a/test/js/ajax/ajaxEvents.test.ts
+++ b/test/js/ajax/ajaxEvents.test.ts
@@ -87,19 +87,33 @@ describe('Ajax', (): void => {
     })
   })
 
-  // This doesnt work due to some issue with chromium / webkit and hijacking link clicks...
-  // describe('Ajax data-method links', () => {
-  //   const events = [...ALWAYS_SENT_EVENTS, 'ajax:response:error', 'ajax:error']
+  describe('Ajax data-method links', () => {
+    const events = [...ALWAYS_SENT_EVENTS, 'ajax:response:error', 'ajax:error']
 
-  //   const getLink = (): void => {
-  //     window.mrujs = mrujs.start();
-  //     (findByTestId('get-link') as HTMLAnchorElement).click()
-  //   }
+    const getLink = (): void => {
+      window.mrujs = mrujs.start();
+      (findByTestId('get-link') as HTMLAnchorElement).click()
+    }
 
-  //   events.forEach((event) => {
-  //     it(`Should fire an ${event} for link GET requests`, () => {
-  //       assertFired(event, getLink)
-  //     })
-  //   })
-  // })
+    events.forEach((event) => {
+      it(`Should fire an ${event} for link GET requests`, () => {
+        assertFired(event, getLink)
+      })
+    })
+  })
+
+  describe('Ajax data-method links work on nested elements', () => {
+    const events = [...ALWAYS_SENT_EVENTS, 'ajax:response:error', 'ajax:error']
+
+    const deleteLink = (): void => {
+      window.mrujs = mrujs.start();
+      (findByTestId('delete-button') as HTMLButtonElement).click()
+    }
+
+    events.forEach((event) => {
+      it(`Should fire an ${event} for link DELETE requests`, () => {
+        assertFired(event, deleteLink)
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Status

Ready

## Additional Notes

Handles logic around remote links with nested elements. Previously it was calling `event.target`. This changes it to `event.currentTarget` which will properly identify the anchor submitting the request.