### PR TITLE
fix: event listeners now attach properly when attributes change

### DIFF
--- a/src/clickHandler.ts
+++ b/src/clickHandler.ts
@@ -36,7 +36,7 @@ export class ClickHandler {
     })
   }
 
-  observerCallback (nodeList: NodeList): void {
+  observerCallback (nodeList: Node[]): void {
     ClickHandler.queries.forEach((obj) => {
       obj.selectors.forEach((selector) => {
         nodeList.forEach((node) => {

--- a/src/confirm.ts
+++ b/src/confirm.ts
@@ -55,7 +55,7 @@ export class Confirm {
     })
   }
 
-  observerCallback (nodeList: NodeList): void {
+  observerCallback (nodeList: Node[]): void {
     this.queries.forEach((obj) => {
       obj.selectors.forEach((selector) => {
         nodeList.forEach((node) => {

--- a/src/method.ts
+++ b/src/method.ts
@@ -18,7 +18,7 @@ export class Method {
     })
   }
 
-  observerCallback (nodeList: NodeList): void {
+  observerCallback (nodeList: Node[]): void {
     nodeList.forEach((node) => {
       if (match(node, window.mrujs.querySelectors.linkClickSelector)) {
         node.addEventListener('click', this.handle)

--- a/src/mrujs.ts
+++ b/src/mrujs.ts
@@ -133,12 +133,20 @@ export class Mrujs {
 
   addedNodesCallback (mutationList: MutationRecord[], _observer: MutationObserver): void {
     for (const mutation of mutationList) {
-      this.toggler.enableElementObserverCallback(mutation.addedNodes)
-      this.clickHandler.observerCallback(mutation.addedNodes)
-      this.confirmClass.observerCallback(mutation.addedNodes)
-      this.toggler.disableElementObserverCallback(mutation.addedNodes)
-      this.toggler.handleDisabledObserverCallback(mutation.addedNodes)
-      this.method.observerCallback(mutation.addedNodes)
+      let addedNodes: Node[]
+
+      if (mutation.type === 'attributes') {
+        addedNodes = [mutation.target]
+      } else {
+        addedNodes = Array.from(mutation.addedNodes)
+      }
+
+      this.toggler.enableElementObserverCallback(addedNodes)
+      this.clickHandler.observerCallback(addedNodes)
+      this.confirmClass.observerCallback(addedNodes)
+      this.toggler.disableElementObserverCallback(addedNodes)
+      this.toggler.handleDisabledObserverCallback(addedNodes)
+      this.method.observerCallback(addedNodes)
     }
   }
 

--- a/src/toggler.ts
+++ b/src/toggler.ts
@@ -49,7 +49,7 @@ export class Toggler {
     this.removeListeners(this.enableElementConditions, this.boundEnableElement)
   }
 
-  enableElementObserverCallback (nodeList: NodeList): void {
+  enableElementObserverCallback (nodeList: Node[]): void {
     this.enableElementConditions.forEach((condition) => {
       const { selector, event } = condition
       nodeList.forEach((node) => {
@@ -72,7 +72,7 @@ export class Toggler {
     this.removeListeners(this.disableElementConditions, this.boundDisableElement)
   }
 
-  disableElementObserverCallback (nodeList: NodeList): void {
+  disableElementObserverCallback (nodeList: Node[]): void {
     this.disableElementConditions.forEach((condition) => {
       const { selector, event } = condition
       nodeList.forEach((node) => {
@@ -95,7 +95,7 @@ export class Toggler {
     this.removeListeners(this.handleDisabledConditions, this.handleDisabledElement)
   }
 
-  handleDisabledObserverCallback (nodeList: NodeList): void {
+  handleDisabledObserverCallback (nodeList: Node[]): void {
     this.handleDisabledConditions.forEach((condition) => {
       const { selector, event } = condition
       nodeList.forEach((node) => {


### PR DESCRIPTION
## Status

* Needs Review

## Related Issue(s)

(that thing I mentioned on discord)

## Additional Notes

I noticed that remote link behavior wasn't being correctly attaching if you added `data-remote` to an existing link.

Digging into things, it looks like `mrujs.addedNodesCallback` was calling the various observer callbacks with `mutation.addedNodes` which is blank when the mutation is an attribute change.

I've updated the behavior in `mrujs.addedNodesCallback` to use `mutation.target` if the mutation is an attribute change.

This also required updating the method signatures of the observerCallback functions from `NodeList` to `Node[]`,  because the browser doesn't let you create your own NodeLists.

This change is important to get the cablecar plugin fully working.  That plugin adds data-remote attributes to links but this PR is necessary to have those newly added data-remote attributes have any effect.