### PR TITLE
preventDefault on ajax:complete cancels navigation

### DIFF
--- a/src/navigationAdapter.ts
+++ b/src/navigationAdapter.ts
@@ -104,6 +104,8 @@ export class NavigationAdapter {
    * Currently, this only fires on successful form submissions.
    */
   private navigateViaEvent (event: CustomEvent): void {
+    if (event.defaultPrevented) return
+
     const { element, fetchResponse, fetchRequest } = event.detail
     if (fetchResponse == null) return
 


### PR DESCRIPTION
## Status

* Needs Review

## Additional Notes

This PR allows the developer to disable the navigation adapter by calling `event.preventDefault` on the `ajax:complete` event

Thanks for talking about my legacy RailsUJS projects that assume navigation won't occur on html responses.  Right now, the best way I could find to disable the navigationAdapter was to register an `ajax:success/error` that calls `event.preventDefault`.  If you register this handler directly on the form it executes before mrujs's handler and prevents the `ajax:complete` event (and the navigation adapter) from firing.

It's not ideal to disable all `ajax:complete` errors, so this change allows the option to cancel directly from an `ajax:complete` error attached to the form.