### PR TITLE
Make default mime type more permissive

### DIFF
--- a/src/plugins/cableCar.ts
+++ b/src/plugins/cableCar.ts
@@ -29,7 +29,7 @@ export class CableCar {
     this.observer = new MutationObserver(this.boundScanner)
     this.elements = []
     this.cableReady = cableReady
-    this.mimeType = (mimeType ?? 'application/vnd.cable-ready.json')
+    this.mimeType = (mimeType ?? 'application/vnd.cable-ready.json, */*')
   }
 
   get name (): string {
@@ -94,7 +94,13 @@ export class CableCar {
     const fetchResponse = event.detail.fetchResponse
 
     if (fetchResponse == null) return
-    if ((fetchResponse.contentType?.match(this.mimeType)) == null) return
+
+    const contentTypeMatchesAccept = this.mimeType
+      .split(/, */)
+      .reduce((result: boolean, s: string) => {
+        return result || !((fetchResponse.contentType?.match(s)) == null)
+      }, false)
+    if (!contentTypeMatchesAccept) return
 
     fetchResponse.responseJson.then((response: JSON) => {
       this.cableReady.perform(response)


### PR DESCRIPTION
## Status

* Needs Review

## Related Issue(s)

https://discord.com/channels/629472241427415060/683317077423292582/876474972346912798

## Additional Notes

Making the mime type more permissive allows Rails to render html templates to strings inside the controller action while still sending a cable_ready content type in the response.

This also adjusts the match against the mime type to allow it to handle compound mime types.