### PR TITLE
fix: uses UJS based navigation for AJAX GET links.

### DIFF
--- a/src/http/fetchResponse.ts
+++ b/src/http/fetchResponse.ts
@@ -5,6 +5,7 @@ import { FetchResponseInterface } from '../types'
 // https://github.com/hotwired/turbo/blob/main/src/http/fetch_response.ts
 export function FetchResponse (response: Response): FetchResponseInterface {
   const succeeded = response.ok
+  const status = response.status
   const failed = !succeeded
   const clientError = (response.status >= 400 && response.status <= 499)
   const serverError = (response.status >= 500 && response.status <= 599)
@@ -49,6 +50,7 @@ export function FetchResponse (response: Response): FetchResponseInterface {
     text,
     html,
     json,
-    response
+    response,
+    status
   }
 }

--- a/src/navigationAdapter.ts
+++ b/src/navigationAdapter.ts
@@ -87,12 +87,12 @@ function navigateViaEvent (event: CustomEvent): void {
 
   const { element, fetchResponse, fetchRequest } = event.detail
 
-  if (!shouldNavigate(element, fetchRequest, fetchResponse)) return
+  if (!shouldNavigate(element, fetchResponse)) return
 
   navigate(fetchResponse, element, fetchRequest)
 }
 
-function shouldNavigate (element: HTMLElement, fetchRequest: FetchRequestInterface, fetchResponse: FetchResponseInterface): boolean {
+function shouldNavigate (element: HTMLElement, fetchResponse: FetchResponseInterface): boolean {
   if (element.dataset.ujsNavigate === 'false') return false
   if (fetchResponse == null) return false
 
@@ -103,9 +103,6 @@ function shouldNavigate (element: HTMLElement, fetchRequest: FetchRequestInterfa
     console.error('Successful form submissions must redirect')
     return false
   }
-
-  // Dont navigate on <a data-method="get"> for links.
-  if (element instanceof HTMLAnchorElement && fetchRequest.isGetRequest) return false
 
   return true
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,6 +122,7 @@ export interface FetchResponseInterface {
   redirected: boolean
   clientError: boolean
   serverError: boolean
+  status: number
   location: URL
   contentType: string | null
   isHtml: boolean

--- a/test/rails/dummy/app/controllers/static_controller.rb
+++ b/test/rails/dummy/app/controllers/static_controller.rb
@@ -1,4 +1,7 @@
 class StaticController < ApplicationController
   def index
   end
+
+  def no_content
+  end
 end

--- a/test/rails/dummy/app/views/remote_links/index.html.erb
+++ b/test/rails/dummy/app/views/remote_links/index.html.erb
@@ -13,3 +13,7 @@
 <div>
   <a href="/" data-remote="true" data-method="delete" id="remote-delete-link">Remote delete link!</a>
 </div>
+
+<div>
+  <a href="/" data-remote="true" data-method="get" data-ujs-navigate="false">no navigate get</a>
+</div>

--- a/test/rails/dummy/config/routes.rb
+++ b/test/rails/dummy/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   root "static#index"
 
+  post "/no_content", to: "static#no_content"
+
   resources :posts
   resources :remote_links
 end

--- a/test/rails/dummy/test/system/remote_link_tests.rb
+++ b/test/rails/dummy/test/system/remote_link_tests.rb
@@ -2,22 +2,28 @@ module RemoteLinkTests
   extend ActiveSupport::Concern
 
   included do
-    test "it should not navigate on a data-remote get request" do
+    test "it should navigate on a data-remote get request" do
       assert_current_path remote_links_path
       click_link "Remote Get Link"
-      assert_current_path remote_links_path
+      assert_current_path root_path
     end
 
     test "it should use ajax if only data-method is specifed, we assume remote" do
       assert_current_path remote_links_path
       click_link "Method Get Link"
-      assert_current_path remote_links_path
+      assert_current_path root_path
     end
 
     test "should navigate for a regular link" do
       assert_current_path remote_links_path
       click_link "Go home"
       assert_current_path root_path
+    end
+
+    test "Should not navigate with data-ujs-navigate='false'" do
+      assert_current_path remote_links_path
+      click_link "no navigate get"
+      assert_current_path remote_links_path
     end
   end
 end


### PR DESCRIPTION
## Status

Ready

## Related Issue(s)

## Additional Notes

This was an issue raised by @Erlingur where ajax get links didnt have the same behavior as rails-ujs navigation.

Before I merge + release, anyone have an issue with this?

IF you dont want your page to navigate, your links should look like this:

```html
<a href="/blah" data-method="get" data-ujs-navigate="false">Dont navigate!</a>
```