### PR TITLE
fix: submitter already defined on Event prototype

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,6 +33,7 @@ function compressionPlugins(tsconfig = "tsconfig.json") {
 
 export default [
   {
+    external: ["morphdom"],
     input: "src/index.ts",
     output: [
       {
@@ -40,7 +41,7 @@ export default [
         file: "dist/mrujs.umd.js",
         format: "umd",
         sourcemap: true,
-        exports: "named"
+        exports: "named",
       },
       {
         file: "dist/mrujs.module.js",
@@ -60,7 +61,7 @@ export default [
         file: "plugins/dist/mrujs.umd.js",
         format: "umd",
         sourcemap: true,
-        exports: "named"
+        exports: "named",
       },
       {
         file: "plugins/dist/mrujs.module.js",

--- a/src/polyfills/submit-event.ts
+++ b/src/polyfills/submit-event.ts
@@ -28,6 +28,9 @@ function clickCaptured (event: Event): void {
   // No need to continue, polyfill not needed.
   if ('SubmitEvent' in window) return
 
+  // Polyfill has already been run, do not pass go.
+  if ('submitter' in Event.prototype) return
+
   addEventListener('click', clickCaptured, true)
 
   Object.defineProperty(Event.prototype, 'submitter', {


### PR DESCRIPTION
## Status

Ready

## Related Issue(s)

* fixes #113

Will submit a PR to Turbo as well so ordering of dependencies wont matter.

As of right now, you must import Turbo before mrujs for unsupported browsers.