### PR TITLE
Fix: CableCar refactor

### DIFF
--- a/docs/src/_documentation/how_tos/integrate-cablecar.md
+++ b/docs/src/_documentation/how_tos/integrate-cablecar.md
@@ -33,24 +33,25 @@ mrujs.start({
 })
 ```
 
-Now, any element with `data-cable-car` will get `data-remote="true"` and
-`data-type="json"` which means that anything with `data-cable-car` will
-perform an AJAX request, return JSON, and then automatically performs
-CableReady operations on the JSON payload.
+Now, any link or form with `data-method="<method>"` or `data-remote="true"` will have the following `Accept` header:
 
-## [Example](#example)
-
-```html
-<a href="/url" data-method="patch" data-cable-car>
-  I get used by CableCar!
-</a>
+```js
+"text/vnd.cablecar.json, */*"
 ```
 
-Turns into:
+which means any link or form with `data-method="<method>"` or `data-remote="true"` will
+perform an AJAX request, return JSON if it finds a cablecar response on your Rails server,
+and then automatically performs CableCar operations defined in the JSON payload return.
+
+## [Examples](#examples)
 
 ```html
-<a href="/url" data-method="patch" data-remote="true" data-type="json" data-cable-car="">
-  Click me
+<a href="/url" data-method="patch">
+  I get used by CableCar!
 </a>
+
+<form data-remote="true">
+ <input type="submit" value="Submit me and get CableCar JSON back!">
+</form>
 ```
 

--- a/plugins/src/asyncConfirm/index.ts
+++ b/plugins/src/asyncConfirm/index.ts
@@ -12,7 +12,6 @@ export function AsyncConfirm (): Record<string, unknown> {
 function initialize (): void {
   window.customElements.define('mrujs-confirm', MrujsConfirmElement)
 
-  // @ts-expect-error
   window.mrujs.registerConfirm('data-async-confirm', handleAsyncConfirm)
 }
 
@@ -35,7 +34,6 @@ function handleAsyncConfirm (event: Event): void {
   const eventType = event.type
   if (eventType === 'change') return
 
-  // @ts-expect-error
   const mrujs = window.mrujs
   mrujs.stopEverything(event)
 

--- a/plugins/src/cableCar.ts
+++ b/plugins/src/cableCar.ts
@@ -22,7 +22,7 @@ export class CableCar {
   }
 
   initialize (): void {
-    const anyHeader = window.mrujs.config.mimeTypes.any
+    const anyHeader = window.mrujs.mimeTypes.any
     window.mrujs.registerMimeTypes([
       { shortcut: 'any', header: `${this.mimeType}, ${anyHeader}` }
     ])

--- a/plugins/src/cableCar.ts
+++ b/plugins/src/cableCar.ts
@@ -21,12 +21,19 @@ export class CableCar {
     return 'CableCar'
   }
 
+  initialize (): void {
+    const anyHeader = window.mrujs.config.mimeTypes.any
+    window.mrujs.registerMimeTypes([
+      { shortcut: 'any', header: `${this.mimeType}, ${anyHeader}` }
+    ])
+  }
+
   connect (): void {
-    document.addEventListener("ajax:complete", this.boundPerform)
+    document.addEventListener('ajax:complete', this.boundPerform)
   }
 
   disconnect (): void {
-    document.removeEventListener("ajax:complete", this.boundPerform)
+    document.removeEventListener('ajax:complete', this.boundPerform)
   }
 
   perform (event: CustomEvent): void {

--- a/plugins/src/cableCar.ts
+++ b/plugins/src/cableCar.ts
@@ -6,27 +6,15 @@ interface CableCarConfig {
   mimeType?: string
 }
 
-interface ExtendedElement extends HTMLElement {
-  observer?: MutationObserver
-}
-
 export class CableCar {
-  observer: MutationObserver
-  elements: ExtendedElement[]
   cableReady: CableReady
   mimeType: string
-
   boundPerform: EventListener
-  boundScanner: MutationCallback & EventListener
 
   constructor (cableReady: CableReady, { mimeType }: CableCarConfig = {}) {
-    this.boundScanner = this.scanner.bind(this)
-    this.boundPerform = this.perform.bind(this) as EventListener
-
-    this.observer = new MutationObserver(this.boundScanner)
-    this.elements = []
     this.cableReady = cableReady
     this.mimeType = (mimeType ?? 'application/vnd.cable-ready.json')
+    this.boundPerform = this.perform.bind(this) as EventListener
   }
 
   get name (): string {
@@ -34,65 +22,17 @@ export class CableCar {
   }
 
   connect (): void {
-    this.scanner() // Attach to all currently existing nodes / elements.
-
-    // Now lets scan the dom on any big updates.
-    document.addEventListener('DOMContentLoaded', this.boundScanner)
-    document.addEventListener('turbolinks:load', this.boundScanner)
-    document.addEventListener('turbo:load', this.boundScanner)
-    document.addEventListener('ajax:complete', this.boundPerform)
-
-    this.observer.observe(document.documentElement, {
-      attributeFilter: ['data-cable-car'],
-      childList: true,
-      subtree: true
-    })
+    document.addEventListener("ajax:complete", this.boundPerform)
   }
 
   disconnect (): void {
-    this.elements.forEach((element: ExtendedElement) => {
-      element.observer?.disconnect()
-    })
-
-    document.removeEventListener('DOMContentLoaded', this.boundScanner)
-    document.removeEventListener('turbolinks:load', this.boundScanner)
-    document.removeEventListener('turbo:load', this.boundScanner)
-    document.removeEventListener('ajax:complete', this.boundPerform)
-  }
-
-  scanner (): void {
-    if (this.isPreview) return
-
-    Array.from(document.querySelectorAll('[data-cable-car]'))
-      .filter(element => {
-        return ((element as ExtendedElement).observer == null)
-      })
-      .forEach(element => {
-        const el = element as ExtendedElement
-        el.dataset.type = this.mimeType
-        el.dataset.remote = 'true'
-        el.observer = new MutationObserver(this.integrity)
-        el.observer.observe(element, {
-          attributeFilter: ['data-type', 'data-remote']
-        })
-        this.elements.push(el)
-      })
-  }
-
-  integrity (mutations: MutationRecord[]): void {
-    mutations.forEach(mutation => {
-      const element = mutation.target as HTMLElement
-      if (!element.hasAttribute('data-type')) element.dataset.type = this.mimeType
-      if (!element.hasAttribute('data-remote')) element.dataset.remote = 'true'
-    })
+    document.removeEventListener("ajax:complete", this.boundPerform)
   }
 
   perform (event: CustomEvent): void {
     const fetchResponse = event.detail.fetchResponse
 
-    if (fetchResponse == null) return
-
-    if (fetchResponse.contentType == null) return
+    if (fetchResponse?.contentType == null) return
     if (!this.isCableReadyResponse(fetchResponse.contentType)) return
 
     fetchResponse.json().then((response: JSON) => {
@@ -100,13 +40,6 @@ export class CableCar {
     }).catch((err: Error) => {
       console.error(err)
     })
-  }
-
-  get isPreview (): boolean {
-    return (
-      document.documentElement.hasAttribute('data-turbolinks-preview') ||
-      document.documentElement.hasAttribute('data-turbo-preview')
-    )
   }
 
   isCableReadyResponse (contentType: string): boolean {

--- a/plugins/src/index.ts
+++ b/plugins/src/index.ts
@@ -1,3 +1,14 @@
+import { Adapter, MrujsInterface } from '../../src/types'
+
+declare global {
+  interface Window {
+    mrujs: MrujsInterface
+    Rails: MrujsInterface
+    Turbolinks?: Adapter
+    Turbo?: Adapter
+  }
+}
+
 export * from './cableCar'
 export * from './asyncConfirm'
 export * from './jsErb'

--- a/plugins/src/jsErb.ts
+++ b/plugins/src/jsErb.ts
@@ -29,7 +29,6 @@ function injectScriptIntoHead (event: CustomEvent): void {
 
   if (csp != null) script.setAttribute('nonce', csp)
 
-  // @ts-expect-error
   window.mrujs.enableElement(event)
 
   event.detail?.fetchResponse?.text().then((html: string) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,7 @@ import './polyfills'
 import { Mrujs } from './mrujs'
 import { FetchRequest } from './http/fetchRequest'
 import { FetchResponse } from './http/fetchResponse'
-import { Adapter } from './navigationAdapter'
-import { MrujsInterface } from './types'
+import { Adapter, MrujsInterface } from './types'
 
 // This is required for typescript checking in tests
 declare global {

--- a/src/navigationAdapter.ts
+++ b/src/navigationAdapter.ts
@@ -1,15 +1,17 @@
-import { expandUrl, urlsAreEqual } from './utils/url'
 import morphdom from 'morphdom'
 
-import { MrujsPluginInterface, SnapshotCacheInterface, Locateable, FetchRequestInterface, FetchResponseInterface } from './types'
+import { expandUrl, urlsAreEqual } from './utils/url'
+import {
+  Adapter, MrujsPluginInterface, SnapshotCacheInterface,
+  Locateable, FetchRequestInterface, FetchResponseInterface,
+  VisitAction
+} from './types'
 
 const ALLOWABLE_ACTIONS = [
   'advance',
   'replace',
   'restore'
 ]
-
-export type VisitAction = 'advance' | 'replace' | 'restore'
 
 export interface NavigationAdapterInterface extends MrujsPluginInterface {
   cacheContains: (url: Locateable) => boolean
@@ -237,28 +239,4 @@ function determineAction (element: HTMLElement): VisitAction {
   }
 
   return action as VisitAction
-}
-
-export interface Adapter {
-  visit: (location: Locateable, { action }: { action: VisitAction }) => void
-  clearCache: () => void
-
-  // Turbolinks
-  supported?: boolean
-  Snapshot: {
-    wrap: (str: string) => string
-  }
-  controller: {
-    cache: SnapshotCacheInterface
-  }
-
-  // Turbo
-  PageSnapshot?: {
-    fromHTMLString: (str: string) => string
-  }
-  navigator: {
-    view: {
-      snapshotCache: SnapshotCacheInterface
-    }
-  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -158,3 +158,29 @@ export interface FetchRequestInterface {
   isGetRequest: boolean
   cancel: (event?: CustomEvent) => void
 }
+
+export interface Adapter {
+  visit: (location: Locateable, { action }: { action: VisitAction }) => void
+  clearCache: () => void
+
+  // Turbolinks
+  supported?: boolean
+  Snapshot: {
+    wrap: (str: string) => string
+  }
+  controller: {
+    cache: SnapshotCacheInterface
+  }
+
+  // Turbo
+  PageSnapshot?: {
+    fromHTMLString: (str: string) => string
+  }
+  navigator: {
+    view: {
+      snapshotCache: SnapshotCacheInterface
+    }
+  }
+}
+
+export type VisitAction = 'advance' | 'replace' | 'restore'

--- a/test/js/ajax/ajaxEvents.test.ts
+++ b/test/js/ajax/ajaxEvents.test.ts
@@ -8,6 +8,7 @@ import mrujs from '../../../src/index'
 describe('Ajax', (): void => {
   afterEach((): void => {
     sinon.restore()
+    window.mrujs.stop()
   })
 
   describe('Remote Disabled Forms', (): void => {
@@ -103,7 +104,7 @@ describe('Ajax', (): void => {
   })
 
   describe('Ajax data-method links work on nested elements', () => {
-    const events = [...ALWAYS_SENT_EVENTS, 'ajax:response:error', 'ajax:error']
+    const events = ALWAYS_SENT_EVENTS
 
     const deleteLink = (): void => {
       window.mrujs = mrujs.start();

--- a/test/js/plugins/cableCar.test.ts
+++ b/test/js/plugins/cableCar.test.ts
@@ -14,14 +14,6 @@ describe('CableCar with standard config', () => {
     window.mrujs.stop()
   })
 
-  it('Should automatically add data-type and data-remote to data-cable-car elements', () => {
-    mrujs.start({ plugins: [cableCar] })
-    const link = document.querySelector('#cable-car-link') as HTMLElement
-    assert.equal(link.dataset.type, cableCar.mimeType)
-    assert.equal(link.dataset.remote, 'true')
-    window.mrujs.stop()
-  })
-
   it('Should return true for the given content type', () => {
     assert(cableCar.isCableReadyResponse("application/vnd.cable-ready.json; charset='utf-8'"))
   })

--- a/test/js/plugins/cableCarMimeType.test.ts
+++ b/test/js/plugins/cableCarMimeType.test.ts
@@ -13,7 +13,7 @@ describe('CableCar with custom config', () => {
     })
 
     assert(window.mrujs.mimeTypes.any.includes(mimeType))
-    assert(window.mrujs.mimeTypes.any.includes("*/*"))
+    assert(window.mrujs.mimeTypes.any.includes('*/*'))
 
     mrujs.stop()
   })

--- a/test/js/plugins/cableCarMimeType.test.ts
+++ b/test/js/plugins/cableCarMimeType.test.ts
@@ -12,10 +12,8 @@ describe('CableCar with custom config', () => {
       plugins: [cableCar]
     })
 
-    const link = document.querySelector('#cable-car-link') as HTMLElement
-
-    assert.equal(link.dataset.type, mimeType)
-    assert.equal(link.dataset.remote, 'true')
+    assert(window.mrujs.mimeTypes.any.includes(mimeType))
+    assert(window.mrujs.mimeTypes.any.includes("*/*"))
 
     mrujs.stop()
   })

--- a/tsconfig-plugins.json
+++ b/tsconfig-plugins.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["./plugins"],
+  "include": ["./plugins", "./src/types.ts"],
   "exclude": ["./plugins/dist"],
   "compilerOptions": {
     "outDir": "./plugins/dist"


### PR DESCRIPTION
## Status

Ready

## Related Issue(s)

Refactors how cablecar attaches headers.

## Notable Changes

End users now only need to specify `data-remote` or `data-method` and all AJAX requests will default to using the CableCar header. If a user wants to opt-out on a per element basis, they should pass in a `data-type="<type>"`
