### PR TITLE
fix: disable form submits from Turbo

### DIFF
--- a/src/elementDisabler.ts
+++ b/src/elementDisabler.ts
@@ -33,10 +33,10 @@ export function ElementDisabler (): MrujsPluginInterface {
 }
 
 function getQueries (): EventQueryInterface[] {
-  const { formSubmitSelector, linkClickSelector, buttonClickSelector, inputChangeSelector } = window.mrujs.querySelectors
+  const { formInputClickSelector, formSubmitSelector, linkClickSelector, buttonClickSelector, inputChangeSelector } = window.mrujs.querySelectors
 
   return [
-    { event: 'click', selectors: [buttonClickSelector.selector, linkClickSelector.selector] },
+    { event: 'click', selectors: [buttonClickSelector.selector, linkClickSelector.selector, formInputClickSelector.selector] },
     { event: 'ajax:send', selectors: [formSubmitSelector.selector] },
     { event: 'change', selectors: [inputChangeSelector.selector] }
   ]

--- a/src/elementDisabler.ts
+++ b/src/elementDisabler.ts
@@ -33,11 +33,12 @@ export function ElementDisabler (): MrujsPluginInterface {
 }
 
 function getQueries (): EventQueryInterface[] {
-  const { formInputClickSelector, formSubmitSelector, linkClickSelector, buttonClickSelector, inputChangeSelector } = window.mrujs.querySelectors
+  const { formSubmitSelector, linkClickSelector, buttonClickSelector, inputChangeSelector } = window.mrujs.querySelectors
 
   return [
-    { event: 'click', selectors: [buttonClickSelector.selector, linkClickSelector.selector, formInputClickSelector.selector] },
+    { event: 'click', selectors: [buttonClickSelector.selector, linkClickSelector.selector] },
     { event: 'ajax:send', selectors: [formSubmitSelector.selector] },
+    { event: 'turbo:submit-start', selectors: ['form'] },
     { event: 'change', selectors: [inputChangeSelector.selector] }
   ]
 }

--- a/src/elementEnabler.ts
+++ b/src/elementEnabler.ts
@@ -39,7 +39,8 @@ function getQueries (): EventQueryInterface[] {
     formSubmitSelector.selector, inputChangeSelector.selector]
   return [
     { event: AJAX_EVENTS.ajaxComplete, selectors: selectors },
-    { event: AJAX_EVENTS.ajaxStopped, selectors: selectors }
+    { event: AJAX_EVENTS.ajaxStopped, selectors: selectors },
+    { event: 'turbo:submit-end', selectors: selectors }
   ]
 }
 


### PR DESCRIPTION
## Status

Ready

## Related Issue(s)

Fixes #141 

## Additional Notes

Any time a turbo-submit is sent, the form will be disabled, and then re-enabled when the submit finishes.
