### PR TITLE
fix: allow remote submissions on formInputSelectors

### DIFF
--- a/docs/src/_documentation/references/ajax_lifecycle.md
+++ b/docs/src/_documentation/references/ajax_lifecycle.md
@@ -45,7 +45,7 @@ request // => Request
 fetchResponse // => FetchResponse (wrapper around Response)
 response // => Response
 submitter // => The button clicked to initiate the submit. Button / Link element
-submission // => Either FormSubmission or LinkSubmission.
+submission // => Either FormSubmission or MethodSubmission.
 status // => available for ajax:success, ajax:complete, ajax:response:error, ajax:error
 ```
 


### PR DESCRIPTION
## Status

Ready

## Additional Notes

(Docs to follow)
- Supports `data-remote` on formInputSelectors (`input`, `select`, `textarea`)
- Allows specifying `data-params` which will take a 1 level deep stringified object:

```js
// Allowed
data-params='{"name": "value"}'

// Disallowed
data-params='{"user": { "name": "value" }'
```

Other examples:

https://gist.github.com/rickychilcott/b964fdd3506564aa810bd562c69e9ea0

If coming from Rails, this is allowed:

```rb
data: { params: {
                  action_item: {
                      completed: !action_item.completed? ? "1" : "0" }
                   }.to_param
              }
           }
```

This is because `to_param` (or `to_query`) turns the hash into this: `action_item: "completed=1"`

https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-to_query