### PR TITLE
Don't disable `button` elements if form is using browser validation + invalid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,6 @@ docs/public
 # nodenv version file
 .node-version
 .pnpm-lock.yaml
+
+
+.pnpm-store/

--- a/demo/index.html
+++ b/demo/index.html
@@ -75,6 +75,43 @@
       <input type="submit" value="Submit" />
     </form>
 
+    <form
+      data-testid="GET-200-constraint"
+      method="GET"
+      action="/demo/index.html"
+      data-remote="true"
+    >
+      <input type="hidden" name="authenticity_token">
+      <label for="user[name]">GET 200 with constraint validation (button)</label>
+      <input type="text" name="user[name]" required />
+      <button type="submit" data-disable-with="Submitting...">Submit</button>
+    </form>
+
+    <form
+      data-testid="GET-200-constraint-novalidate"
+      method="GET"
+      action="/demo/index.html"
+      data-remote="true"
+      novalidate
+    >
+      <input type="hidden" name="authenticity_token">
+      <label for="user[name]">GET 200 with required attribute, but `novalidate` (will submit)</label>
+      <input type="text" name="user[name]" required />
+      <button type="submit" data-disable-with="Submitting...">Submit</button>
+    </form>
+
+    <form
+      data-testid="GET-200-constraint-input"
+      method="GET"
+      action="/demo/index.html"
+      data-remote="true"
+    >
+      <input type="hidden" name="authenticity_token">
+      <label for="user[name]">GET 200 with constraint validation & input type=submit</label>
+      <input type="text" name="user[name]" required />
+      <input type="submit" value="Submit" data-disable-with="Submitting..." />
+    </form>
+
     <a href="/" data-method="delete">DELETE</a>
     <button data-async-confirm="Hi">
       Yo

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mrujs",
   "amdName": "mrujs",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "UJS for modern javascript.",
   "source": "src/index.ts",
   "main": "./dist/index.umd.js",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+  - esbuild

--- a/src/elementDisabler.ts
+++ b/src/elementDisabler.ts
@@ -80,6 +80,11 @@ function disableFormElements (form: HTMLFormElement): void {
 function disableFormElement (element: HTMLFormElement): void {
   if (element.dataset.ujsDisabled != null) return
 
+  // If an invalid form uses the default constraint validation behavior, the browser prevents submission, so we
+  // should not disable the element
+  const form = element?.form
+  if (form?.noValidate == false && form?.checkValidity() == false) return
+
   const replacement = element.getAttribute('data-disable-with')
 
   if (replacement != null) {


### PR DESCRIPTION
## Description

* If a form is using the browser's Constraint Validation API to provide interactive validation errors, we should not disable a button on the form as part of the Mrujs remote submission.
	* This is because the browser will automatically prevent submission on its own, and present the errors for the user to correct
* If we do not early-return in `disableFormElement` in this case, the form becomes locked and cannot be submitted because its submit buttons are disabled.
* We need to check if the form has its `noValidate` set to `true`, otherwise we do not disable the button if the form has bypassed the constraint validation API (and is still invalid according to`form.checkValidity`)

I added test forms to the demo page for various mixtures of constraint validation + the submit button being a `button` or `input[type=submit]`

## Status

* (Needs Review)

## Related Issue(s)

* #219 

## Additional Notes

* I tried writing tests for this, but was unable to find the right mixture of code to test that the element was not actually disabled